### PR TITLE
Prevent submission of invalid tags

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -18,6 +18,12 @@
         </ignoreFiles>
     </projectFiles>
     <issueHandlers>
+        <!-- PHPUnit Data Providers are always "un-used" -->
+        <PossiblyUnusedMethod>
+            <errorLevel type="suppress">
+                <directory name="test" />
+            </errorLevel>
+        </PossiblyUnusedMethod>
     </issueHandlers>
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>

--- a/src/AssetClient.php
+++ b/src/AssetClient.php
@@ -9,6 +9,7 @@ use CuyZ\Valinor\MapperBuilder;
 use Fig\Http\Message\RequestMethodInterface;
 use Override;
 use Prismic\Asset\Exception\CommunicationFailure;
+use Prismic\Asset\Exception\InvalidTagName;
 use Prismic\Asset\Exception\RequestFailure;
 use Prismic\Asset\Exception\UnexpectedResponse;
 use Prismic\Asset\Model\Asset;
@@ -32,6 +33,7 @@ use function implode;
 use function json_encode;
 use function ltrim;
 use function sprintf;
+use function strlen;
 
 use const JSON_THROW_ON_ERROR;
 
@@ -86,6 +88,7 @@ final readonly class AssetClient implements Client
         string|null $alt = null,
         array $tags = [],
     ): Asset {
+        self::assertValidTagList($tags);
         $boundary = '--__X_Prismic-Asset-Boundary__--';
 
         $payload = [
@@ -160,6 +163,8 @@ final readonly class AssetClient implements Client
     #[Override]
     public function patchAssetMetaData(AssetPatch $patch): Asset
     {
+        self::assertValidTagList($patch->tags ?? []);
+
         $payload = $patch->toArray();
         if (isset($payload['tags']) && $payload['tags'] !== []) {
             $payload['tags'] = $this->resolveTags($payload['tags']);
@@ -212,6 +217,8 @@ final readonly class AssetClient implements Client
     #[Override]
     public function createTag(string $tagName): AssetTag
     {
+        self::assertValidTag($tagName);
+
         $request = $this->createRequest(RequestMethodInterface::METHOD_POST, '/tags')
             ->withHeader('Content-Type', 'application/json')
             ->withBody($this->streamFactory->createStream(
@@ -304,6 +311,24 @@ final readonly class AssetClient implements Client
                 );
         } catch (Throwable $e) {
             throw new UnexpectedResponse('Failed to parse response payload', 0, $e);
+        }
+    }
+
+    /** @param non-empty-string $tag */
+    private static function assertValidTag(string $tag): void
+    {
+        if (strlen($tag) <= Client::MAX_TAG_LENGTH) {
+            return;
+        }
+
+        throw InvalidTagName::for($tag);
+    }
+
+    /** @param list<non-empty-string> $tags */
+    private static function assertValidTagList(array $tags): void
+    {
+        foreach ($tags as $tag) {
+            self::assertValidTag($tag);
         }
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Prismic\Asset;
 
+use Prismic\Asset\Exception\InvalidTagName;
 use Prismic\Asset\Model\Asset;
 use Prismic\Asset\Model\AssetPatch;
 use Prismic\Asset\Model\AssetTag;
@@ -17,6 +18,8 @@ interface Client
      * The hard limit imposed in GET /assets
      */
     public const int RESULT_LIMIT = 10;
+
+    public const int MAX_TAG_LENGTH = 20;
 
     /**
      * Fetch a list of all assets
@@ -45,6 +48,8 @@ interface Client
      * @param non-empty-string|null  $credits     Optional, copyright info
      * @param non-empty-string|null  $alt         Optional, Alt text for images
      * @param list<non-empty-string> $tags        Optional list of tag names to apply to the file
+     *
+     * @throws InvalidTagName If any of the given tags are invalid.
      */
     public function uploadAsset(
         string $fileContent,
@@ -56,6 +61,11 @@ interface Client
         array $tags = [],
     ): Asset;
 
+    /**
+     * Updates asset meta data to the desired values contained in the argument
+     *
+     * @throws InvalidTagName If any of the given tags are invalid.
+     */
     public function patchAssetMetaData(AssetPatch $patch): Asset;
 
     /**
@@ -67,6 +77,8 @@ interface Client
      * Create an asset tag
      *
      * @param non-empty-string $tagName Tag names must be between 3 and 20 characters inclusive
+     *
+     * @throws InvalidTagName If the given tag is invalid.
      */
     public function createTag(string $tagName): AssetTag;
 }

--- a/src/Exception/InvalidTagName.php
+++ b/src/Exception/InvalidTagName.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Prismic\Asset\Exception;
+
+use InvalidArgumentException;
+
+use function sprintf;
+
+final class InvalidTagName extends InvalidArgumentException implements ApiError
+{
+    public static function for(string $name): self
+    {
+        return new self(sprintf(
+            'Tag names cannot be more than 20 characters long. "%s" does not satisfy those criteria',
+            $name,
+        ));
+    }
+}

--- a/test/Unit/AssetClientTest.php
+++ b/test/Unit/AssetClientTest.php
@@ -13,9 +13,11 @@ use Laminas\Diactoros\Response;
 use Laminas\Diactoros\StreamFactory;
 use Laminas\Diactoros\UriFactory;
 use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Prismic\Asset\AssetClient;
 use Prismic\Asset\Exception\CommunicationFailure;
+use Prismic\Asset\Exception\InvalidTagName;
 use Prismic\Asset\Exception\RequestFailure;
 use Prismic\Asset\Exception\UnexpectedResponse;
 use Prismic\Asset\Model\AssetPatch;
@@ -24,6 +26,7 @@ use Psr\Http\Message\ResponseInterface;
 
 use function file_get_contents;
 use function json_encode;
+use function str_repeat;
 
 use const JSON_THROW_ON_ERROR;
 
@@ -401,5 +404,21 @@ class AssetClientTest extends TestCase
         $this->http->addException(new NetworkException('Foo', new Request()));
         $this->expectException(CommunicationFailure::class);
         $this->client->getTags();
+    }
+
+    /** @return list<array{0: non-empty-string}> */
+    public static function invalidTags(): array
+    {
+        return [
+            [str_repeat('a', 21)],
+        ];
+    }
+
+    /** @param non-empty-string $tag */
+    #[DataProvider('invalidTags')]
+    public function testCreateTagThrowsExceptionForInvalidTag(string $tag): void
+    {
+        $this->expectException(InvalidTagName::class);
+        $this->client->createTag($tag);
     }
 }


### PR DESCRIPTION
Prismic allows tags of up to 20 characters in length.